### PR TITLE
Run misspell_fixer in docker container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu
+
+RUN apt-get update && \
+    apt-get install -y git && \
+    git clone https://github.com/ka7/misspell_fixer.git && \
+    apt-get remove -y git && \
+    apt -y autoremove && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+ENTRYPOINT ["/misspell_fixer/misspell_fixer.sh"]
+CMD ["-h"]

--- a/README.md
+++ b/README.md
@@ -19,6 +19,19 @@ And also important to note to be extra careful when fixing public APIs!
 
 A manual review is always needed to verify that nothing has been broken.
 
+### Run in docker container.
+
+If you are mac or Windows users, this script doesn't work properly. You can run it in docker container.
+
+```
+docker build -t fixer .
+cd <Folder>
+alias fixer='docker run -ti --rm -v $(pwd):/app fixer '
+fixer -h
+fixer -D .
+```
+
+
 ### Synopsis
     
     misspell_fixer	[OPTION] target


### PR DESCRIPTION
The reason why I need run `misspell_fixer` in docker container is, the script seems only work in Linux environment.  I can't get result in macOS. 

With this `Dockerfile`, you can build and run it as a local command on MAC or Windows.

```
docker build -t fixer . 
cd <Folder>
alias fixer='docker run -ti --rm -v $(pwd):/app fixer '
fixer -D .
```